### PR TITLE
[Level.1] 성격 유형 검사하기

### DIFF
--- a/level2/두 큐 합 같게 만들기/jiyun
+++ b/level2/두 큐 합 같게 만들기/jiyun
@@ -1,0 +1,54 @@
+# 문제
+
+[성격 유형 검사하기](https://school.programmers.co.kr/learn/courses/30/lessons/118666)
+
+# 시간 복잡도
+
+o(N)
+
+# 내용
+
+- 문제 유형(-> mbti)과 선택지 별 얻을 수 있는 점수(->point)를 미리 정의한다.
+- 성격 유형을 산출하기 위해 스코어를 계산할 때 배열을 8자리로 만들지 않고 4자리로 만든 뒤 부호를 보고 유형을 결정한다.
+- test()를 통해 totalScore를 산출하며, getResult()를 통해 totalScore로 부터 성격 유형을 도출한다.
+- test()에서는 문제 유형이 5번째 이상, 즉 +- 부호가 반대로 되어야 하는 문항의 경우 스코어의 부호를 바꾸어 더한다.
+
+# 코드
+
+```javascript
+const mbti = ['RT', 'CF', 'JM', 'AN', 'TR', 'FC', 'MJ', 'NA']
+
+const point = [-3, -2, -1, 0, 1, 2, 3]
+
+const test = (survey, choices) => {
+  const totalScore = [0, 0, 0, 0]
+  for (let i = 0; i < survey.length; i++) {
+    let idx = mbti.indexOf(survey[i])
+    let score = point[choices[i] - 1]
+    if (idx >= 4) {
+      if (score > 0) score = -score
+      else score = 0 - score
+      idx -= 4
+    }
+    totalScore[idx] += score
+  }
+  return totalScore
+}
+
+const getResult = totalScore => {
+  let result = ''
+  for (let i = 0; i < 4; i++) {
+    if (totalScore[i] > 0) {
+      result += mbti[i][1]
+    } else {
+      result += mbti[i][0]
+    }
+  }
+  return result
+}
+
+function solution(survey, choices) {
+  const totalScore = test(survey, choices)
+  return getResult(totalScore)
+}
+```


### PR DESCRIPTION
### [Level.1] 성격 유형 검사하기
### 시간 복잡도
o(N)

### 내용
- 문제 유형(-> mbti)과 선택지 별 얻을 수 있는 점수(->point)를 미리 정의한다.
- 성격 유형을 산출하기 위해 스코어를 계산할 때 배열을 8자리로 만들지 않고 4자리로 만든 뒤 부호를 보고 유형을 결정한다.
- test()를 통해 totalScore를 산출하며, getResult()를 통해 totalScore로 부터 성격 유형을 도출한다.
- test()에서는 문제 유형이 5번째 이상, 즉 +- 부호가 반대로 되어야 하는 문항의 경우 스코어의 부호를 바꾸어 더한다.

### 결과
![스크린샷 2023-11-22 오전 11 50 57](https://github.com/v-studies/algorithm/assets/76979903/896db9b4-4134-4b4f-9078-9b0b35ee768b)
