### PR TITLE
[Level.2] 멀쩡한 사각형

### DIFF
--- a/level2/멀쩡한 사각형/eunseo.md
+++ b/level2/멀쩡한 사각형/eunseo.md
@@ -1,0 +1,77 @@
+# [level 2] 멀쩡한 사각형 - 62048 
+
+[문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/62048) 
+
+### 성능 요약
+
+메모리: 75.5 MB, 시간: 0.06 ms
+
+### 구분
+
+코딩테스트 연습 > Summer／Winter Coding（2019）
+
+### 채점결과
+
+정확성: 100.0<br/>합계: 100.0 / 100.0
+
+### 제출 일자
+
+2023년 12월 1일 23:52:4
+
+### 문제 설명
+
+<p>가로 길이가 Wcm, 세로 길이가 Hcm인 직사각형 종이가 있습니다. 종이에는 가로, 세로 방향과 평행하게 격자 형태로 선이 그어져 있으며, 모든 격자칸은 1cm x 1cm 크기입니다. 이 종이를 격자 선을 따라 1cm × 1cm의 정사각형으로 잘라 사용할 예정이었는데, 누군가가 이 종이를 대각선 꼭지점 2개를 잇는 방향으로 잘라 놓았습니다. 그러므로 현재 직사각형 종이는 크기가 같은 직각삼각형 2개로 나누어진 상태입니다. 새로운 종이를 구할 수 없는 상태이기 때문에, 이 종이에서 원래 종이의 가로, 세로 방향과 평행하게 1cm × 1cm로 잘라 사용할 수 있는 만큼만 사용하기로 하였습니다. <br>
+가로의 길이 W와 세로의 길이 H가 주어질 때, 사용할 수 있는 정사각형의 개수를 구하는 solution 함수를 완성해 주세요.</p>
+
+<h5>제한사항</h5>
+
+<ul>
+<li>W, H : 1억 이하의 자연수</li>
+</ul>
+
+<h4>입출력 예</h4>
+<table class="table">
+        <thead><tr>
+<th>W</th>
+<th>H</th>
+<th>result</th>
+</tr>
+</thead>
+        <tbody><tr>
+<td>8</td>
+<td>12</td>
+<td>80</td>
+</tr>
+</tbody>
+      </table>
+<h5>입출력 예 설명</h5>
+
+<p>입출력 예 #1<br>
+가로가 8, 세로가 12인 직사각형을 대각선 방향으로 자르면 총 16개 정사각형을 사용할 수 없게 됩니다. 원래 직사각형에서는 96개의 정사각형을 만들 수 있었으므로, 96 - 16 = 80 을 반환합니다.</p>
+
+<p><img src="https://grepp-programmers.s3.amazonaws.com/files/production/ee895b2cd9/567420db-20f4-4064-afc3-af54c4a46016.png" title="" alt="572957326.92.png"></p>
+
+### 풀이 과정
+1. gcd를 구한다. gcd만큼 패턴이 반복되는 점을 이용한다.
+2. 작은 패턴으로 봤을 때 (w/gcd) + (h/gcd) -1 만큼 대각선에 영향을 받는다.
+3. 이점을 이용하여 답을 구하면 된다. 
+
+```java
+class Solution {
+    public long solution(int w, int h) {
+
+        long gcd = 0;
+
+        long min = Math.min(w, h);
+
+        for(int i=1; i<=min; i++){
+            if(w % i == 0 && h % i ==0) {
+                gcd = Math.max(gcd, i);
+            }
+        }
+
+
+        return ((long) w * h) - ((w /gcd)  + (h /gcd) - 1) * gcd;
+    }
+}
+```


### PR DESCRIPTION
# [level 2] 멀쩡한 사각형 - 62048 

[문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/62048) 

### 성능 요약

메모리: 75.5 MB, 시간: 0.06 ms

### 구분

코딩테스트 연습 > Summer／Winter Coding（2019）

### 채점결과

정확성: 100.0<br/>합계: 100.0 / 100.0

### 제출 일자

2023년 12월 1일 23:52:4

### 문제 설명

<p>가로 길이가 Wcm, 세로 길이가 Hcm인 직사각형 종이가 있습니다. 종이에는 가로, 세로 방향과 평행하게 격자 형태로 선이 그어져 있으며, 모든 격자칸은 1cm x 1cm 크기입니다. 이 종이를 격자 선을 따라 1cm × 1cm의 정사각형으로 잘라 사용할 예정이었는데, 누군가가 이 종이를 대각선 꼭지점 2개를 잇는 방향으로 잘라 놓았습니다. 그러므로 현재 직사각형 종이는 크기가 같은 직각삼각형 2개로 나누어진 상태입니다. 새로운 종이를 구할 수 없는 상태이기 때문에, 이 종이에서 원래 종이의 가로, 세로 방향과 평행하게 1cm × 1cm로 잘라 사용할 수 있는 만큼만 사용하기로 하였습니다. <br>
가로의 길이 W와 세로의 길이 H가 주어질 때, 사용할 수 있는 정사각형의 개수를 구하는 solution 함수를 완성해 주세요.</p>

<h5>제한사항</h5>

<ul>
<li>W, H : 1억 이하의 자연수</li>
</ul>

<h4>입출력 예</h4>
<table class="table">
        <thead><tr>
<th>W</th>
<th>H</th>
<th>result</th>
</tr>
</thead>
        <tbody><tr>
<td>8</td>
<td>12</td>
<td>80</td>
</tr>
</tbody>
      </table>
<h5>입출력 예 설명</h5>

<p>입출력 예 #1<br>
가로가 8, 세로가 12인 직사각형을 대각선 방향으로 자르면 총 16개 정사각형을 사용할 수 없게 됩니다. 원래 직사각형에서는 96개의 정사각형을 만들 수 있었으므로, 96 - 16 = 80 을 반환합니다.</p>

<p><img src="https://grepp-programmers.s3.amazonaws.com/files/production/ee895b2cd9/567420db-20f4-4064-afc3-af54c4a46016.png" title="" alt="572957326.92.png"></p>

### 풀이 과정
1. gcd를 구한다. gcd만큼 패턴이 반복되는 점을 이용한다.
2. 작은 패턴으로 봤을 때 (w/gcd) + (h/gcd) -1 만큼 대각선에 영향을 받는다.
3. 이점을 이용하여 답을 구하면 된다. 